### PR TITLE
Fix "Shidan Tweaks & Fixes" ordering

### DIFF
--- a/masterlist.json
+++ b/masterlist.json
@@ -253,7 +253,6 @@
       "Name":"Overhauls & Big additions/world changes",
       "Mod":[
          "ABSOLVER.mod",
-         "Shidan's Tweaks & Fixes.mod",
          "RecruitPrisoners.mod",
          "Adventurers Guild - Lore Friendly Recruitment.mod",
          "Minor Factions Expansion.mod",


### PR DESCRIPTION
Already present in the first group, breaks ST&F patches order as well.